### PR TITLE
add missing datasets in and create r3 folder

### DIFF
--- a/intake/catalogs/c3s.yaml
+++ b/intake/catalogs/c3s.yaml
@@ -1,11 +1,11 @@
 sources:
   c3s-cmip6:
     args:
-      urlpath: '{{ CATALOG_DIR }}/c3s-cmip6/c3s-cmip6_v20210611.csv.gz'
+      urlpath: '{{ CATALOG_DIR }}/c3s-cmip6/r3/c3s-cmip6_v20210625.csv.gz'
     cache:
     - argkey: urlpath
       type: file
     description: c3s-cmip6 datasets
     driver: intake.source.csv.CSVSource
     metadata:
-      last_updated: '2021-06-11T07:52:00Z'
+      last_updated: '2021-06-25T07:22:27Z'


### PR DESCRIPTION
Update release3 catalog with missing datasets from release2. 

There were 481 missing, 477 of these have been successfully scanned in