### PR TITLE
added csw_kwargs

### DIFF
--- a/intake/catalogs/c3s.yaml
+++ b/intake/catalogs/c3s.yaml
@@ -10,4 +10,4 @@ sources:
     description: c3s-cmip6 datasets
     driver: intake.source.csv.CSVSource
     metadata:
-      last_updated: '2021-06-25T07:22:27Z'
+      last_updated: '2021-09-22T10:22:27Z'

--- a/intake/catalogs/c3s.yaml
+++ b/intake/catalogs/c3s.yaml
@@ -2,9 +2,11 @@ sources:
   c3s-cmip6:
     args:
       urlpath: '{{ CATALOG_DIR }}/c3s-cmip6/r3/c3s-cmip6_v20210625.csv.gz'
-    cache:
-    - argkey: urlpath
-      type: file
+      csv_kwargs:
+        blocksize: null
+        compression: gzip
+        dtype:
+          level: object
     description: c3s-cmip6 datasets
     driver: intake.source.csv.CSVSource
     metadata:


### PR DESCRIPTION
This PR updates the catalog `c3s.yml` so it can be used by the latest versions of `intake`, `fsspec`, `dask`.