### PR TITLE
Fix intake catalog for c3s-cordex

### DIFF
--- a/intake/catalogs/c3s.yaml
+++ b/intake/catalogs/c3s.yaml
@@ -31,6 +31,7 @@ sources:
         compression: gzip
         dtype:
           level: object
+          experiment_id: object
     description: c3s-cordex datasets
     driver: intake.source.csv.CSVSource
     metadata:

--- a/intake/catalogs/c3s.yaml
+++ b/intake/catalogs/c3s.yaml
@@ -26,14 +26,12 @@ sources:
   c3s-cordex:
     args:
       urlpath: '{{ CATALOG_DIR }}/c3s-cordex/c3s-cordex_v20211216.csv.gz'
-    csv_kwargs:
-      blocksize: null
-      compression: gzip
-      dtype:
-        level: object
+      csv_kwargs:
+        blocksize: null
+        compression: gzip
+        dtype:
+          level: object
     description: c3s-cordex datasets
     driver: intake.source.csv.CSVSource
     metadata:
       last_updated: '2021-12-16T09:53:40Z'
-
-


### PR DESCRIPTION
Changes:
* fixed formatting in yaml catalog for c3s-cordex: `csv_kwargs`
* added `dtype` for c3s-cordex: `experiment_id: object`